### PR TITLE
Restricted django-meta major version due incompatibilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def find_version(*parts):
 
 
 requires = [
-    "django-meta>1.5",
+    "django-meta>1.5,<2",
     "wagtail>1.4,<3.0",
 ]
 


### PR DESCRIPTION
Solving issue [#12](https://github.com/bashu/wagtail-metadata-mixin/issues/12)